### PR TITLE
Add theme variables and dark mode toggle

### DIFF
--- a/assets/mobirise/css/mbr-additional.css
+++ b/assets/mobirise/css/mbr-additional.css
@@ -122,8 +122,8 @@ body {
 }
 .btn-secondary,
 .btn-secondary:active {
-  background-color: #ff3366 !important;
-  border-color: #ff3366 !important;
+  background-color: var(--primary-color) !important;
+  border-color: var(--primary-color) !important;
   color: #ffffff !important;
 }
 .btn-secondary:hover,
@@ -294,14 +294,14 @@ body {
 .btn-secondary-outline.focus,
 .btn-secondary-outline.active {
   color: #ffffff;
-  background-color: #ff3366;
-  border-color: #ff3366;
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
 }
 .btn-secondary-outline.disabled,
 .btn-secondary-outline:disabled {
   color: #ffffff !important;
-  background-color: #ff3366 !important;
-  border-color: #ff3366 !important;
+  background-color: var(--primary-color) !important;
+  border-color: var(--primary-color) !important;
 }
 .btn-info-outline,
 .btn-info-outline:active {
@@ -421,7 +421,7 @@ body {
   color: #149dcc !important;
 }
 .text-secondary {
-  color: #ff3366 !important;
+  color: var(--primary-color) !important;
 }
 .text-success {
   color: #f7ed4a !important;
@@ -650,7 +650,7 @@ blockquote {
 .xdsoft_datetimepicker .xdsoft_calendar td:hover,
 .xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box > div > div:hover {
   color: #ffffff !important;
-  background: #ff3366 !important;
+  background: var(--primary-color) !important;
   box-shadow: none !important;
 }
 .lazy-bg {
@@ -777,7 +777,7 @@ section.lazy-placeholder:after {
   }
 }
 .cid-uH1Rkt4gAZ .mbr-text {
-  color: #232323;
+  color: var(--text-color);
 }
 .cid-uH1RY6dj6E {
   background: #ffffff;
@@ -860,7 +860,7 @@ section.lazy-placeholder:after {
   }
 }
 .cid-toFKrUncZU .mbr-text {
-  color: #232323;
+  color: var(--text-color);
   text-align: left;
 }
 .cid-tlX7lJnpOk {

--- a/assets/theme/css/style.css
+++ b/assets/theme/css/style.css
@@ -2,8 +2,20 @@
  * Mobirise v4 theme (https://mobirise.com/)
  * Copyright 2017 Mobirise
  */
+:root {
+  --primary-color: #ff3366;
+  --background-color: #eeeeee;
+  --text-color: #232323;
+}
+
+.dark-mode {
+  --primary-color: #ff3366;
+  --background-color: #232323;
+  --text-color: #eeeeee;
+}
+
 section {
-  background-color: #eeeeee;
+  background-color: var(--background-color);
 }
 
 .form-control:focus {
@@ -81,7 +93,8 @@ figure {
 }
 
 body {
-  color: #232323;
+  color: var(--text-color);
+  background-color: var(--background-color);
 }
 
 h1,
@@ -128,7 +141,7 @@ blockquote {
   padding: 10px 0 10px 20px;
   position: relative;
   border-left: 2px solid;
-  border-color: #ff3366;
+  border-color: var(--primary-color);
 }
 
 input:-webkit-autofill, input:-webkit-autofill:hover, input:-webkit-autofill:focus, input:-webkit-autofill:active {

--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
 </script>
 <!-- /Analytics -->
 
+<button id="toggle-dark-mode">Toggle Dark Mode</button>
 
-  
-  <section class="header14 cid-rQRsyRMg1E" id="header14-0">
+    <section class="header14 cid-rQRsyRMg1E" id="header14-0">
 
     
 
@@ -680,8 +680,12 @@
             </div>
         </div>
     </div>
-</section><section class="display-7" style="padding: 0;align-items: center;justify-content: center;flex-wrap: wrap;    align-content: center;display: flex;position: relative;height: 4rem;"><a href="https://mobiri.se/3022804" style="flex: 1 1;height: 4rem;position: absolute;width: 100%;z-index: 1;"><img alt="" style="height: 4rem;" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></a><p style="margin: 0;text-align: center;" class="display-7">&#8204;</p><a style="z-index:1" href="https://mobirise.com/builder/ai-website-builder.html">Free AI Website Software</a></section><script src="assets/popper/popper.min.js"></script>  <script src="assets/web/assets/jquery/jquery.min.js"></script>  <script src="assets/bootstrap/js/bootstrap.min.js"></script>  <script src="assets/tether/tether.min.js"></script>  <script src="assets/smoothscroll/smooth-scroll.js"></script>  <script src="assets/mbr-popup-btns/mbr-popup-btns.js"></script>  <script src="assets/theme/js/script.js"></script>  <script src="assets/formoid/formoid.min.js"></script>  
-  
-  
+</section><section class="display-7" style="padding: 0;align-items: center;justify-content: center;flex-wrap: wrap;    align-content: center;display: flex;position: relative;height: 4rem;"><a href="https://mobiri.se/3022804" style="flex: 1 1;height: 4rem;position: absolute;width: 100%;z-index: 1;"><img alt="" style="height: 4rem;" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></a><p style="margin: 0;text-align: center;" class="display-7">&#8204;</p><a style="z-index:1" href="https://mobirise.com/builder/ai-website-builder.html">Free AI Website Software</a></section><script src="assets/popper/popper.min.js"></script>  <script src="assets/web/assets/jquery/jquery.min.js"></script>  <script src="assets/bootstrap/js/bootstrap.min.js"></script>  <script src="assets/tether/tether.min.js"></script>  <script src="assets/smoothscroll/smooth-scroll.js"></script>  <script src="assets/mbr-popup-btns/mbr-popup-btns.js"></script>  <script src="assets/theme/js/script.js"></script>  <script src="assets/formoid/formoid.min.js"></script>
+<script>
+  document.getElementById("toggle-dark-mode").addEventListener("click", function () {
+    document.body.classList.toggle("dark-mode");
+  });
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- define reusable theme color variables and dark-mode overrides
- refactor CSS to use the new variables for primary and text colors
- add a toggle button and script to switch dark mode on the page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689504845e8c83218c83cc3802356f26