### PR TITLE
Replace contact form with mailto link

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,20 +62,11 @@
                 </div>
 
                 <div class="media-container-column">
-                    <!---Formbuilder Form--->
-                    <form action="https://mobirise.eu/" method="POST" class="mbr-form form-with-styler" data-form-title="Mobirise Form"><input type="hidden" name="email" data-form-email="true" value="hOg1JojBWeKP5sjeYfQBqbj7CB3B7GgBci6amovc+dZD9odWw8uLKaJSNFRJQBbCW/e6BJCc6y5n39HxhnDqPRYkU1AoqTVzbfQXbWV5Wt5IsENx8H1JM3xLNiOqkoym">
-                        <div class="row form-inline">
-                            <div hidden="hidden" data-form-alert="" class="alert alert-success col-12">Message sent, thank you!</div>
-                            <div hidden="hidden" data-form-alert-danger="" class="alert alert-danger col-12">
-                            </div>
+                    <div class="row form-inline">
+                        <div class="col-auto buttons-wrap">
+                            <a class="btn btn-primary display-4" href="mailto:contact@apb-ldn.org?subject=Website%20Enquiry">EMAIL ME</a>
                         </div>
-                        <div class="dragArea row form-inline">
-                            <div class="col-auto form-group" data-for="email">
-                                <input type="email" name="email" data-form-field="Email" required="required" class="form-control input-sm input-inverse display-7" placeholder="Enter your address" id="email-header14-0">
-                            </div>
-                            <div class="col-auto buttons-wrap"><button type="submit" class="btn btn-primary display-4" href="https://www.linkedin.com/in/arthurlaudrain/" target="_blank">FOLLOW ME</button></div>
-                        </div>
-                    </form><!---Formbuilder Form--->
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove Mobirise contact form
- add simple mailto link for contacting

## Testing
- `tidy -q -e index.html`


------
https://chatgpt.com/codex/tasks/task_e_6895135f85808321a0d1a42ea65d4832