### PR TITLE
feat: restore missing news items

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,35 @@
   <section class="py-12">
     <div class="max-w-7xl mx-auto px-4">
       <h2 class="text-3xl font-bold text-center mb-8 text-indigo-700">Latest news</h2>
-      <div class="md:flex md:items-center md:space-x-8">
+      <div class="my-8">
+        <img src="assets/images/screenshot-2025-06-17-at-13.41.46.png-1776x1115.png" alt="Screenshot from June 17, 2025" class="rounded shadow mx-auto">
+      </div>
+
+      <div class="md:flex md:items-center md:space-x-8 my-8">
+        <div class="md:w-1/2">
+          <p class="mb-4"><strong>Latest publication at the Carnegie Endowment for International Peace, with Joe Devanny.</strong> India’s cyber policies emerge from a domestic political context. To understand India’s cyber diplomacy and its wider approach to cyber statecraft, it is necessary to consider the full politico-strategic context.</p>
+        </div>
+        <div class="md:w-1/2 mt-6 md:mt-0">
+          <a href="https://carnegieendowment.org/research/2025/03/interpreting-indias-cyber-statecraft?lang=en" target="_blank"><img src="assets/images/screenshot-2025-03-31-at-15.36.58.png-436x301.png" alt="Interpreting India's Cyber Statecraft" class="rounded shadow"></a>
+        </div>
+      </div>
+
+      <div class="my-8">
+        <div class="relative" style="padding-top:56.25%;">
+          <iframe class="absolute top-0 left-0 w-full h-full rounded shadow" src="https://www.youtube.com/embed/q0swiUQXbjE?rel=0&amp;showinfo=0" allowfullscreen></iframe>
+        </div>
+      </div>
+
+      <div class="md:flex md:space-x-8 my-8">
+        <div class="md:w-1/2">
+          <img src="assets/images/screenshot-2025-01-28-at-14.40.46-512x698.png" alt="Behind the scene" class="rounded shadow">
+        </div>
+        <div class="md:w-1/2 mt-6 md:mt-0">
+          <img src="assets/images/screenshot-2025-01-28-at-14.40.33-888x585.png" alt="Cyber Statecraft series" class="rounded shadow">
+        </div>
+      </div>
+
+      <div class="md:flex md:items-center md:space-x-8 my-8">
         <div class="md:w-1/2">
           <p class="mb-4">I joined the fifth edition of the Santander-CIDOB Future Leaders Forum in Barcelona, in November 2024. European digital policy: where are we and where are we going? was the title of this edition, which consisted of a speed-debating dialogue session, a dynamic and interactive format. During the event, the young participants brought their reflections, ideas and political proposals in four key areas: the regulation of emerging technologies, the European Union's technological and innovation capacities, the fight against disinformation and European digital sovereignty in a context of geopolitical competition.</p>
         </div>


### PR DESCRIPTION
## Summary
- restore news items from the Mobirise site in their original order
- include Carnegie publication, video embed, behind-the-scenes images, and CIDOB forum update

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895237e36208321b1ea365463ac3292