### PR TITLE
Fix Google Scholar citation parsing and resize news images

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
     <div class="max-w-7xl mx-auto px-4">
       <h2 class="text-3xl font-bold text-center mb-8 text-indigo-700">Latest news</h2>
       <div class="my-8">
-        <img loading="lazy" src="assets/images/screenshot-2025-06-17-at-13.41.46.png-1776x1115.png" alt="Screenshot from June 17, 2025" class="rounded shadow mx-auto w-full max-w-3xl h-auto">
+        <img loading="lazy" src="assets/images/screenshot-2025-06-17-at-13.41.46.png-1776x1115.png" alt="Screenshot from June 17, 2025" class="rounded shadow mx-auto w-full max-w-xl h-auto">
       </div>
 
       <div class="md:flex md:items-center md:space-x-8 my-8">
@@ -66,7 +66,7 @@
           <p class="mb-4"><strong>Latest publication at the Carnegie Endowment for International Peace, with Joe Devanny.</strong> India’s cyber policies emerge from a domestic political context. To understand India’s cyber diplomacy and its wider approach to cyber statecraft, it is necessary to consider the full politico-strategic context.</p>
         </div>
         <div class="md:w-1/2 mt-6 md:mt-0">
-          <a href="https://carnegieendowment.org/research/2025/03/interpreting-indias-cyber-statecraft?lang=en" target="_blank"><img loading="lazy" src="assets/images/screenshot-2025-03-31-at-15.36.58.png-436x301.png" alt="Interpreting India's Cyber Statecraft" class="rounded shadow w-full h-auto"></a>
+          <a href="https://carnegieendowment.org/research/2025/03/interpreting-indias-cyber-statecraft?lang=en" target="_blank"><img loading="lazy" src="assets/images/screenshot-2025-03-31-at-15.36.58.png-436x301.png" alt="Interpreting India's Cyber Statecraft" class="rounded shadow w-full h-auto max-w-md mx-auto"></a>
       </div>
       </div>
 
@@ -78,10 +78,10 @@
 
       <div class="md:flex md:space-x-8 my-8">
         <div class="md:w-1/2">
-          <img loading="lazy" src="assets/images/screenshot-2025-01-28-at-14.40.46-512x698.png" alt="Behind the scene" class="rounded shadow w-full h-auto">
+          <img loading="lazy" src="assets/images/screenshot-2025-01-28-at-14.40.46-512x698.png" alt="Behind the scene" class="rounded shadow w-full h-auto max-w-md mx-auto">
         </div>
         <div class="md:w-1/2 mt-6 md:mt-0">
-          <img loading="lazy" src="assets/images/screenshot-2025-01-28-at-14.40.33-888x585.png" alt="Cyber Statecraft series" class="rounded shadow w-full h-auto">
+          <img loading="lazy" src="assets/images/screenshot-2025-01-28-at-14.40.33-888x585.png" alt="Cyber Statecraft series" class="rounded shadow w-full h-auto max-w-md mx-auto">
         </div>
       </div>
 
@@ -90,7 +90,7 @@
           <p class="mb-4">I joined the fifth edition of the Santander-CIDOB Future Leaders Forum in Barcelona, in November 2024. European digital policy: where are we and where are we going? was the title of this edition, which consisted of a speed-debating dialogue session, a dynamic and interactive format. During the event, the young participants brought their reflections, ideas and political proposals in four key areas: the regulation of emerging technologies, the European Union's technological and innovation capacities, the fight against disinformation and European digital sovereignty in a context of geopolitical competition.</p>
         </div>
         <div class="md:w-1/2 mt-6 md:mt-0">
-          <a href="https://www.cidob.org/en/news/fifth-edition-santander-cidob-future-leaders-forum-brings-together-young-leaders-debate" target="_blank"><img loading="lazy" src="assets/images/cidob2.png-641x359.png" alt="Santander-CIDOB Future Leaders Forum" class="rounded shadow w-full h-auto"></a>
+          <a href="https://www.cidob.org/en/news/fifth-edition-santander-cidob-future-leaders-forum-brings-together-young-leaders-debate" target="_blank"><img loading="lazy" src="assets/images/cidob2.png-641x359.png" alt="Santander-CIDOB Future Leaders Forum" class="rounded shadow w-full h-auto max-w-md mx-auto"></a>
         </div>
       </div>
     </div>
@@ -246,7 +246,7 @@
     const container = document.getElementById('scholar-profile');
     if (!container) return;
     try {
-      const response = await fetch('https://r.jina.ai/http://scholar.google.com/citations%3Fuser%3DEC5PfaUAAAAJ%26hl%3Den%26view_op%3Dlist_works%26sortby%3Dpubdate');
+      const response = await fetch('https://r.jina.ai/https://scholar.google.com/citations?user=EC5PfaUAAAAJ&hl=en&view_op=list_works&sortby=pubdate');
       const html = await response.text();
       const parser = new DOMParser();
       const doc = parser.parseFromString(html, 'text/html');


### PR DESCRIPTION
## Summary
- Replace URL encoding with direct Google Scholar link through r.jina.ai to restore citation count and publication list
- Limit latest news images to reasonable widths for better display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953f95f34c832190c40e50503dedf2