### PR TITLE
feat: improve google scholar fetching

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,25 +245,43 @@
   async function loadScholar() {
     const container = document.getElementById('scholar-profile');
     if (!container) return;
+
+    container.innerHTML = '<p>Loading Google Scholar data…</p>';
+
+    const endpoint = '/api/scholar?user=EC5PfaUAAAAJ';
+
+    const showError = () => {
+      container.innerHTML = `
+        <div class="text-red-600">
+          <p class="mb-2">Unable to load Google Scholar data.</p>
+          <button id="scholar-retry" class="underline text-indigo-700">Retry</button>
+        </div>`;
+      const retry = document.getElementById('scholar-retry');
+      if (retry) retry.addEventListener('click', loadScholar);
+    };
+
     try {
-      const response = await fetch('https://r.jina.ai/https://scholar.google.com/citations?user=EC5PfaUAAAAJ&hl=en&view_op=list_works&sortby=pubdate');
+      const response = await fetch(endpoint);
+      if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
       const html = await response.text();
       const parser = new DOMParser();
       const doc = parser.parseFromString(html, 'text/html');
 
-      const citationCell = doc.querySelector('#gsc_rsb_st .gsc_rsb_std');
-      const totalCitations = citationCell ? citationCell.textContent.trim() : 'N/A';
+      const citationCell = doc.querySelector('#gsc_rsb_st td.gsc_rsb_std');
+      const rows = doc.querySelectorAll('#gsc_a_b .gsc_a_tr');
+      if (!citationCell || rows.length === 0) throw new Error('Unexpected Google Scholar markup');
 
-      const rows = doc.querySelectorAll('.gsc_a_tr');
+      const totalCitations = citationCell.textContent.trim();
+
       const publications = [];
       rows.forEach((row, i) => {
         if (i < 5) {
-          const titleLink = row.querySelector('.gsc_a_at');
-          const citation = row.querySelector('.gsc_a_ac');
+          const titleLink = row.querySelector('a.gsc_a_at');
+          const citation = row.querySelector('a.gsc_a_ac');
           publications.push({
-            title: titleLink ? titleLink.textContent : '',
+            title: titleLink ? titleLink.textContent.trim() : 'Untitled',
             link: titleLink ? 'https://scholar.google.com' + titleLink.getAttribute('href') : '#',
-            citations: citation ? citation.textContent.trim() || '0' : '0'
+            citations: citation ? (citation.textContent.trim() || '0') : '0'
           });
         }
       });
@@ -276,8 +294,8 @@
       htmlContent += '</ul>';
       container.innerHTML = htmlContent;
     } catch (e) {
-      container.innerHTML = '<p>Unable to load Google Scholar data.</p>';
-      console.error(e);
+      console.error('Error loading Google Scholar data:', e);
+      showError();
     }
   }
 


### PR DESCRIPTION
## Summary
- query Google Scholar through `/api/scholar` proxy
- update selectors for citations and publications
- add friendly error handling with retry button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689546d0d7808321a2bd1a224c1e4a0d