### PR TITLE
Add serverless Google Scholar proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+
+# Mac files
+.DS_Store

--- a/api/scholar/index.js
+++ b/api/scholar/index.js
@@ -1,0 +1,59 @@
+const dns = require('node:dns');
+dns.setDefaultResultOrder('ipv4first');
+
+const { ProxyAgent } = require('undici');
+const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+const dispatcher = proxy ? new ProxyAgent(proxy) : undefined;
+
+exports.handler = async function(event) {
+  const params = event.queryStringParameters || {};
+  const user = params.user;
+  const sortby = params.sortby || 'pubdate';
+  if (!user) {
+    return {
+      statusCode: 400,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'text/plain'
+      },
+      body: 'Missing required "user" parameter'
+    };
+  }
+  const url = `https://scholar.google.com/citations?user=${encodeURIComponent(user)}&sortby=${encodeURIComponent(sortby)}`;
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; APB-LDN/1.0; +https://apb-ldn.org)'
+      },
+      dispatcher
+    });
+    if (!response.ok) {
+      return {
+        statusCode: response.status,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': 'text/plain'
+        },
+        body: `Upstream request failed with status ${response.status}`
+      };
+    }
+    const html = await response.text();
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'text/html; charset=utf-8'
+      },
+      body: html
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'text/plain'
+      },
+      body: 'Error fetching Google Scholar data.'
+    };
+  }
+};

--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
 
     container.innerHTML = '<p>Loading Google Scholar data…</p>';
 
-    const endpoint = '/api/scholar?user=EC5PfaUAAAAJ&sortby=pubdate';
+    const endpoint = 'https://apb-ldn.netlify.app/.netlify/functions/scholar?user=EC5PfaUAAAAJ&sortby=pubdate';
     const CACHE_KEY = 'scholarData';
     const CACHE_TIME_KEY = 'scholarDataTime';
     const CACHE_TTL = 1000 * 60 * 60; // 1 hour

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "apb-ldn.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "undici": "^7.13.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add serverless function that fetches Google Scholar HTML and returns it
- point `loadScholar` script to deployed Netlify function
- add package manifest and gitignore for serverless function dependencies

## Testing
- `node -e "const {handler}=require('./api/scholar/index.js');handler({queryStringParameters:{user:'EC5PfaUAAAAJ',sortby:'pubdate'}}).then(r=>{console.log('status',r.statusCode);console.log('body length',r.body.length);}).catch(console.error);"`


------
https://chatgpt.com/codex/tasks/task_e_6895516377848321aa325ea9748f2a57