### PR TITLE
Reduce image sizes in news and media sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
     <div class="max-w-7xl mx-auto px-4">
       <h2 class="text-3xl font-bold text-center mb-8 text-indigo-700">Latest news</h2>
       <div class="my-8">
-        <img loading="lazy" src="assets/images/screenshot-2025-06-17-at-13.41.46.png-1776x1115.png" alt="Screenshot from June 17, 2025" class="rounded shadow mx-auto w-full max-w-xl h-auto">
+        <img loading="lazy" src="assets/images/screenshot-2025-06-17-at-13.41.46.png-1776x1115.png" alt="Screenshot from June 17, 2025" class="rounded shadow mx-auto w-full max-w-lg h-auto">
       </div>
 
       <div class="md:flex md:items-center md:space-x-8 my-8">
@@ -66,7 +66,7 @@
           <p class="mb-4"><strong>Latest publication at the Carnegie Endowment for International Peace, with Joe Devanny.</strong> India’s cyber policies emerge from a domestic political context. To understand India’s cyber diplomacy and its wider approach to cyber statecraft, it is necessary to consider the full politico-strategic context.</p>
         </div>
         <div class="md:w-1/2 mt-6 md:mt-0">
-          <a href="https://carnegieendowment.org/research/2025/03/interpreting-indias-cyber-statecraft?lang=en" target="_blank"><img loading="lazy" src="assets/images/screenshot-2025-03-31-at-15.36.58.png-436x301.png" alt="Interpreting India's Cyber Statecraft" class="rounded shadow w-full h-auto max-w-md mx-auto"></a>
+          <a href="https://carnegieendowment.org/research/2025/03/interpreting-indias-cyber-statecraft?lang=en" target="_blank"><img loading="lazy" src="assets/images/screenshot-2025-03-31-at-15.36.58.png-436x301.png" alt="Interpreting India's Cyber Statecraft" class="rounded shadow w-full h-auto max-w-sm mx-auto"></a>
       </div>
       </div>
 
@@ -78,10 +78,10 @@
 
       <div class="md:flex md:space-x-8 my-8">
         <div class="md:w-1/2">
-          <img loading="lazy" src="assets/images/screenshot-2025-01-28-at-14.40.46-512x698.png" alt="Behind the scene" class="rounded shadow w-full h-auto max-w-md mx-auto">
+          <img loading="lazy" src="assets/images/screenshot-2025-01-28-at-14.40.46-512x698.png" alt="Behind the scene" class="rounded shadow w-full h-auto max-w-sm mx-auto">
         </div>
         <div class="md:w-1/2 mt-6 md:mt-0">
-          <img loading="lazy" src="assets/images/screenshot-2025-01-28-at-14.40.33-888x585.png" alt="Cyber Statecraft series" class="rounded shadow w-full h-auto max-w-md mx-auto">
+          <img loading="lazy" src="assets/images/screenshot-2025-01-28-at-14.40.33-888x585.png" alt="Cyber Statecraft series" class="rounded shadow w-full h-auto max-w-sm mx-auto">
         </div>
       </div>
 
@@ -90,7 +90,7 @@
           <p class="mb-4">I joined the fifth edition of the Santander-CIDOB Future Leaders Forum in Barcelona, in November 2024. European digital policy: where are we and where are we going? was the title of this edition, which consisted of a speed-debating dialogue session, a dynamic and interactive format. During the event, the young participants brought their reflections, ideas and political proposals in four key areas: the regulation of emerging technologies, the European Union's technological and innovation capacities, the fight against disinformation and European digital sovereignty in a context of geopolitical competition.</p>
         </div>
         <div class="md:w-1/2 mt-6 md:mt-0">
-          <a href="https://www.cidob.org/en/news/fifth-edition-santander-cidob-future-leaders-forum-brings-together-young-leaders-debate" target="_blank"><img loading="lazy" src="assets/images/cidob2.png-641x359.png" alt="Santander-CIDOB Future Leaders Forum" class="rounded shadow w-full h-auto max-w-md mx-auto"></a>
+          <a href="https://www.cidob.org/en/news/fifth-edition-santander-cidob-future-leaders-forum-brings-together-young-leaders-debate" target="_blank"><img loading="lazy" src="assets/images/cidob2.png-641x359.png" alt="Santander-CIDOB Future Leaders Forum" class="rounded shadow w-full h-auto max-w-sm mx-auto"></a>
         </div>
       </div>
     </div>
@@ -101,7 +101,7 @@
     <div class="max-w-7xl mx-auto px-4 text-center">
       <h2 class="text-3xl font-bold text-indigo-700 mb-8">Media engagement</h2>
       <a href="https://www.politics.ox.ac.uk/person/arthur-pb-laudrain" target="_blank">
-        <img loading="lazy" src="assets/images/screenshot-2025-01-20-at-17.56.10-1492x1760.png" alt="Media engagement" class="mx-auto rounded shadow w-full max-w-md h-auto">
+        <img loading="lazy" src="assets/images/screenshot-2025-01-20-at-17.56.10-1492x1760.png" alt="Media engagement" class="mx-auto rounded shadow w-full max-w-sm h-auto">
       </a>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- limit maximum width of hero image in Latest News
- shrink other news and media engagement images for balanced layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68956b705990832197108179e5dc7a0e