### PR TITLE
Add privacy and license information pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,11 +236,14 @@
         <iframe class="w-full h-48 rounded" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?key=AIzaSyAtXm0x23nRCgazjDV2Kl3GTHRP411ougQ&amp;q=Encina Hall, 616 Jane Stanford Way, Stanford University, Stanford, CA 94305-6055" allowfullscreen></iframe>
       </div>
     </div>
-    <div class="border-t border-indigo-500 mt-8 pt-4 text-center">
-      <p>© Copyright 2025 APB Laudrain - All Rights Reserved</p>
+      <div class="border-t border-indigo-500 mt-8 pt-4 text-center">
+        <p>© Copyright 2025 APB Laudrain - All Rights Reserved | 
+          <a href="privacy.html" class="underline text-white hover:text-indigo-200">Privacy Policy</a> | 
+          <a href="license.html" class="underline text-white hover:text-indigo-200">Content License</a>
+        </p>
+      </div>
     </div>
-  </div>
- </footer>
+   </footer>
 
 <script>
   async function loadOpenAlex() {

--- a/license.html
+++ b/license.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Content License</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/tailwind.css">
+  <style>body{font-family:'Inter',sans-serif}</style>
+</head>
+<body class="text-gray-800">
+  <main class="max-w-3xl mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold text-indigo-700 mb-4">Content License</h1>
+    <p class="mb-4">Unless otherwise noted, all original text and media on this site are licensed under the <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" class="underline text-indigo-700">Creative Commons Attribution 4.0 International License</a> (CC BY 4.0). You may share and adapt the material provided that you give appropriate credit and indicate if changes were made.</p>
+
+    <p class="mb-4">Third-party content, including images and publications referenced on this site, may be subject to different licensing terms. Such material is used with permission or under fair use and is credited to the respective owners.</p>
+
+    <p class="mb-4">The source code for this website is released under the <a href="https://opensource.org/license/isc-license-txt" target="_blank" class="underline text-indigo-700">ISC License</a> unless otherwise specified.</p>
+
+    <p class="mb-4">If you wish to use content from this site beyond the scope of the above licenses, please contact us at <a href="mailto:contact@apb-ldn.org" class="underline text-indigo-700">contact@apb-ldn.org</a>.</p>
+
+    <p class="mt-8">© 2025 APB Laudrain</p>
+  </main>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/tailwind.css">
+  <style>body{font-family:'Inter',sans-serif}</style>
+</head>
+<body class="text-gray-800">
+  <main class="max-w-3xl mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold text-indigo-700 mb-4">Privacy Policy</h1>
+    <p class="mb-4">This website is operated by APB Laudrain ("we", "us"). We respect your privacy and are committed to protecting it. This notice explains what personal data we process and your rights under the GDPR and the California Consumer Privacy Act (CCPA).</p>
+
+    <h2 class="text-2xl font-semibold text-indigo-700 mt-6 mb-2">Personal Data We Collect</h2>
+    <p class="mb-4">We do not collect personal information unless you choose to contact us directly. Any information you provide via e-mail will be used solely to respond to your inquiry.</p>
+
+    <h2 class="text-2xl font-semibold text-indigo-700 mt-6 mb-2">Third-Party Services</h2>
+    <p class="mb-4">This site uses several external services. These providers may collect usage data and are responsible for their own processing:</p>
+    <ul class="list-disc pl-6 mb-4">
+      <li><strong>Google Fonts</strong> – serves fonts and may log your IP address and browser details.</li>
+      <li><strong>YouTube</strong> – embedded videos may set cookies and track viewing behaviour.</li>
+      <li><strong>OpenAlex</strong> – publication data is requested from the OpenAlex API; request logs may include your IP address and user agent.</li>
+      <li><strong>Google Maps</strong> – embedded maps may collect location data and log your interactions.</li>
+    </ul>
+    <p class="mb-4">Please refer to the respective privacy policies of these providers for more information on their data practices.</p>
+
+    <h2 class="text-2xl font-semibold text-indigo-700 mt-6 mb-2">Cookies</h2>
+    <p class="mb-4">We do not use cookies or similar tracking technologies. Third-party services described above may use cookies; their policies apply.</p>
+
+    <h2 class="text-2xl font-semibold text-indigo-700 mt-6 mb-2">Your Rights</h2>
+    <p class="mb-4">You may request access to, correction of, or deletion of your personal data. Under GDPR and CCPA, you also have the right to restrict or object to processing and to opt out of the sale of personal information (we do not sell personal data). To exercise these rights, contact us at <a href="mailto:contact@apb-ldn.org" class="underline text-indigo-700">contact@apb-ldn.org</a>.</p>
+
+    <h2 class="text-2xl font-semibold text-indigo-700 mt-6 mb-2">Data Retention</h2>
+    <p class="mb-4">We retain personal communications only as long as necessary to respond to you and to comply with legal obligations.</p>
+
+    <h2 class="text-2xl font-semibold text-indigo-700 mt-6 mb-2">Changes</h2>
+    <p class="mb-4">We may update this policy from time to time. The latest version will always be available on this page.</p>
+
+    <p class="mt-8">Effective date: 1 July 2025</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add footer links to new Privacy Policy and Content License pages
- document third-party services and user rights in a GDPR/CCPA-friendly privacy page
- outline content reuse terms and source code licensing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7678dbcac8321bd1821cf1fc8fe24