### PR TITLE
Add script to refresh citation counts

### DIFF
--- a/data/blog_posts.json
+++ b/data/blog_posts.json
@@ -1,0 +1,65 @@
+{
+  "posts": [
+    {
+      "title": "Sovereignty in cyberspace: Balkanization or democratization",
+      "citations": 31
+    },
+    {
+      "title": "France’s New Offensive Cyber Doctrine",
+      "citations": 20
+    },
+    {
+      "title": "Mapping the Known Unknowns of Cybersecurity Education: A Review of Syllabi on Cyber Conflict and Security",
+      "citations": 10
+    },
+    {
+      "title": "France’s ‘strategic autonomy’ takes to space",
+      "citations": 8
+    },
+    {
+      "title": "Avoiding A World War Web: The Paris Call for Trust and Security in Cyberspace",
+      "citations": 5
+    },
+    {
+      "title": "Study on the Use of Reserve Forces in Military Cybersecurity",
+      "citations": 4
+    },
+    {
+      "title": "Russia’s Cyber War: What’s Next and What the European Union Should Do",
+      "citations": 3
+    },
+    {
+      "title": "5G and the Huawei Controversy: Is it About More Than Just Security?",
+      "citations": 3
+    },
+    {
+      "title": "Smart-city Technologies, Government Surveillance and Privacy: Assessing the Potential for Chilling Effects and Existing Safeguards in the ECHR",
+      "citations": 3
+    },
+    {
+      "title": "Interpreting India's Cyber Statecraft",
+      "citations": 1
+    },
+    {
+      "title": "Objectifs rationnels, enjeux bureaucratiques et arbitrages politiques: un examen du modèle français de cyberpolitique",
+      "citations": 0
+    },
+    {
+      "title": "Le Risque Cyber en Droit des Sociétés",
+      "citations": 0
+    },
+    {
+      "title": "France Doubles Down on Countering Foreign Interference Ahead of Key Elections",
+      "citations": 0
+    },
+    {
+      "title": "The State, its Institutions and Processes: Applying Decision-Making Models to French Cyber Security and Defence",
+      "citations": 0
+    },
+    {
+      "title": "Prolifération Nucléaire et Néoréalisme : Les Tentations du Japon Face à la Chine et à la Corée du Nord",
+      "citations": 0
+    }
+  ],
+  "snapshot_date": "2025-09-02"
+}

--- a/scripts/update_citations.js
+++ b/scripts/update_citations.js
@@ -1,0 +1,62 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const URL = 'https://web.archive.org/web/20250902234456/https://scholar.google.com/citations?user=EC5PfaUAAAAJ';
+
+function decodeHtml(str) {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+async function main() {
+  const html = execSync(`curl -L -s ${URL}`).toString('utf8');
+  const rowRegex = /<tr class="gsc_a_tr">([\s\S]*?)<\/tr>/g;
+  const rows = [...html.matchAll(rowRegex)];
+  const articles = rows.map(match => {
+    const row = match[0];
+    const titleMatch = row.match(/<a[^>]*class="gsc_a_at"[^>]*>(.*?)<\/a>/);
+    const title = titleMatch ? decodeHtml(titleMatch[1]).trim() : null;
+    const citeMatch = row.match(/<td class="gsc_a_c"[^>]*>(.*?)<\/td>/);
+    let citations = 0;
+    if (citeMatch) {
+      const numMatch = citeMatch[1].match(/>(\d+)</);
+      if (numMatch) citations = parseInt(numMatch[1], 10);
+    }
+    return { title, citations };
+  }).filter(a => a.title);
+
+  const snapshotMatch = URL.match(/web\/(\d{4})(\d{2})(\d{2})/);
+  const snapshotDate = snapshotMatch ? `${snapshotMatch[1]}-${snapshotMatch[2]}-${snapshotMatch[3]}` : new Date().toISOString().split('T')[0];
+
+  const dataPath = path.join(__dirname, '..', 'data', 'blog_posts.json');
+  let data = { posts: [] };
+  try {
+    data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  } catch (err) {
+    // file does not exist
+  }
+
+  data.snapshot_date = snapshotDate;
+  const map = new Map(data.posts.map(p => [p.title, p]));
+  for (const article of articles) {
+    if (map.has(article.title)) {
+      map.get(article.title).citations = article.citations;
+    } else {
+      map.set(article.title, article);
+    }
+  }
+  data.posts = Array.from(map.values());
+
+  fs.mkdirSync(path.dirname(dataPath), { recursive: true });
+  fs.writeFileSync(dataPath, JSON.stringify(data, null, 2) + '\n');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Node script to fetch an archived Google Scholar profile and collect article citation counts
- store counts in `data/blog_posts.json` and record the snapshot date

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7838152cc83219ceca9f8e3427087