### PR TITLE
Integrate blog posts into OpenAlex widget

### DIFF
--- a/data/blog_posts.json
+++ b/data/blog_posts.json
@@ -1,0 +1,37 @@
+[
+  {
+    "title": "France Doubles Down on Countering Foreign Interference Ahead of Key Elections",
+    "link": "https://www.lawfaremedia.org/article/france-doubles-down-countering-foreign-interference-ahead-key-elections",
+    "source": "Lawfare",
+    "date": "2021-11-22",
+    "citations": 0
+  },
+  {
+    "title": "Avoiding A World War Web: The Paris Call for Trust and Security in Cyberspace",
+    "link": "https://www.lawfaremedia.org/article/avoiding-world-war-web-paris-call-trust-and-security-cyberspace",
+    "source": "Lawfare",
+    "date": "2018-12-04",
+    "citations": 5
+  },
+  {
+    "title": "France’s New Offensive Cyber Doctrine",
+    "link": "https://www.lawfaremedia.org/article/frances-new-offensive-cyber-doctrine",
+    "source": "Lawfare",
+    "date": "2019-02-26",
+    "citations": 20
+  },
+  {
+    "title": "Mapping the Known Unknowns of Cybersecurity Education",
+    "link": "https://www.cfr.org/blog/mapping-known-unknowns-cybersecurity-education",
+    "source": "Council on Foreign Relations",
+    "date": "2020-02-03",
+    "citations": 7
+  },
+  {
+    "title": "Interpreting India's Cyber Statecraft",
+    "link": "https://carnegieendowment.org/research/2025/03/interpreting-indias-cyber-statecraft?lang=en",
+    "source": "Carnegie Endowment for International Peace",
+    "date": "2025-03-27",
+    "citations": 0
+  }
+]

--- a/index.html
+++ b/index.html
@@ -246,6 +246,100 @@
    </footer>
 
 <script>
+  async function loadBlogPosts() {
+    const CACHE_KEY = 'blogPosts';
+    const CACHE_TTL = 1000 * 60 * 20; // 20 minutes
+
+    const cached = localStorage.getItem(CACHE_KEY);
+    if (cached) {
+      const cachedData = JSON.parse(cached);
+      if (Date.now() - cachedData.updated < CACHE_TTL) {
+        return cachedData.posts;
+      }
+    }
+
+    const feeds = [
+      { url: 'https://feeds.feedburner.com/lawfareblog', tags: ['dc\:creator'], source: 'Lawfare' }
+    ];
+
+    const posts = [];
+
+    for (const feed of feeds) {
+      try {
+        const fetchFeed = async url => {
+          try {
+            const r = await fetch(url);
+            if (r.ok) return await r.text();
+          } catch (err) {}
+          const proxy = `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
+          const pr = await fetch(proxy);
+          if (!pr.ok) throw new Error(`Proxy fetch failed for ${url}`);
+          return pr.text();
+        };
+
+        const text = await fetchFeed(feed.url);
+        const doc = new window.DOMParser().parseFromString(text, 'application/xml');
+        doc.querySelectorAll('item').forEach(item => {
+          const creator = feed.tags
+            .map(tag => item.querySelector(tag))
+            .find(Boolean);
+          if (!creator || !/laudrain/i.test(creator.textContent || '')) return;
+          const title = item.querySelector('title')?.textContent || 'Untitled';
+          const link = item.querySelector('link')?.textContent;
+          const pub = item.querySelector('pubDate')?.textContent;
+          if (link) {
+            posts.push({
+              title,
+              link,
+              year: pub ? new Date(pub).getFullYear() : '',
+              date: pub ? new Date(pub).getTime() : 0,
+              source: feed.source,
+              isBlog: true
+            });
+          }
+        });
+      } catch (e) {
+        console.error('Error loading feed', feed.url, e);
+      }
+    }
+
+    // load curated posts from static JSON
+    try {
+      const curatedRes = await fetch('data/blog_posts.json');
+      if (curatedRes.ok) {
+        const curated = await curatedRes.json();
+        curated.forEach(p => {
+          posts.push({
+            title: p.title,
+            link: p.link,
+            year: p.date ? new Date(p.date).getFullYear() : '',
+            date: p.date ? new Date(p.date).getTime() : 0,
+            source: p.source,
+            citations: p.citations || 0,
+            isBlog: true
+          });
+        });
+      }
+    } catch (e) {
+      console.error('Error loading curated posts', e);
+    }
+
+    // deduplicate by link or normalized title
+    const normalize = s => (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+    const seen = new Set();
+    const deduped = posts.filter(p => {
+      const key = p.link || normalize(p.title);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    deduped.sort((a, b) => b.date - a.date);
+    const finalPosts = deduped.slice(0, 5);
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ updated: Date.now(), posts: finalPosts }));
+    return finalPosts;
+  }
+
   async function loadOpenAlex() {
     const container = document.getElementById('openalex-profile');
     if (!container) return;
@@ -256,7 +350,7 @@
     const base = 'https://api.openalex.org';
     const mailto = 'mailto=contact@apb-ldn.org';
     const CACHE_KEY = 'openAlexData';
-    const CACHE_TTL = 1000 * 60 * 60; // 1 hour
+    const CACHE_TTL = 1000 * 60 * 20; // 20 minutes
 
     const showError = () => {
       container.innerHTML = `
@@ -268,22 +362,31 @@
       if (retry) retry.addEventListener('click', loadOpenAlex);
     };
 
-    const filterWorks = works => {
-      const seen = new Set();
-      return works.filter(w => {
-        if (!w || !w.link) return false;
-        const key = w.doi || w.link;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      });
+    const dedupeWorks = works => {
+      const normalize = s => (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+      const map = new Map();
+      for (const w of works) {
+        if (!w || !w.title || !w.link) continue;
+        const key = w.doi ? w.doi.toLowerCase() : normalize(w.title) + (w.isBlog ? '_blog' : '');
+        const existing = map.get(key);
+        if (existing) {
+          existing.citations = Math.max(existing.citations || 0, w.citations || 0);
+          if (/doi\.org/.test(w.link) && !/doi\.org/.test(existing.link)) existing.link = w.link;
+          if (!existing.year && w.year) existing.year = w.year;
+          if (!existing.date && w.date) existing.date = w.date;
+          if (!existing.source && w.source) existing.source = w.source;
+        } else {
+          map.set(key, { ...w });
+        }
+      }
+      return [...map.values()];
     };
 
     const renderList = works => works.map(w => `
       <li class="mb-4">
         <a href="${w.link}" target="_blank" rel="noopener noreferrer" class="text-lg text-indigo-700 hover:underline">${w.title}</a>
         <div class="text-sm text-gray-600">
-          ${w.year ? w.year : ''}${w.doi ? ` · <a href="https://doi.org/${w.doi}" target="_blank" rel="noopener noreferrer" class="text-indigo-500 hover:underline">${w.doi}</a>` : ''}${w.citations ? ` · Citations: ${w.citations}` : ''}
+          ${w.year ? w.year : ''}${w.source ? ` · ${w.source}` : ''}${w.doi ? ` · <a href="https://doi.org/${w.doi}" target="_blank" rel="noopener noreferrer" class="text-indigo-500 hover:underline">${w.doi}</a>` : ''}${w.citations ? ` · Citations: ${w.citations}` : ''}
         </div>
       </li>
     `).join('');
@@ -296,7 +399,7 @@
       html += '</div>';
       html += `<ul class="text-left max-w-3xl mx-auto mb-6" data-content="recent">${renderList(data.recent)}</ul>`;
       html += `<ul class="text-left max-w-3xl mx-auto mb-6 hidden" data-content="top">${renderList(data.top)}</ul>`;
-      html += `<p class="text-sm text-gray-500 mt-6">Source: <a href="https://openalex.org/" target="_blank" rel="noopener noreferrer" class="underline text-indigo-700">OpenAlex</a> · Last updated: ${new Date(data.updated).toLocaleString()}<br><em>Not all publications may be covered by the source.</em><br>This publication widget is an experimental module (WIP)</p>`;
+      html += `<p class="text-sm text-gray-500 mt-6">Sources: <a href="https://openalex.org/" target="_blank" rel="noopener noreferrer" class="underline text-indigo-700">OpenAlex</a>, Lawfare RSS, curated entries (e.g., Council on Foreign Relations, Carnegie Endowment) · Last updated: ${new Date(data.updated).toLocaleString()}<br><em>Not all publications may be covered by the sources.</em><br>This publication widget is an experimental module (WIP)</p>`;
       container.innerHTML = html;
 
       const tabs = container.querySelectorAll('.openalex-tab');
@@ -325,9 +428,6 @@
         }
       }
 
-      const authorRes = await fetch(`${base}/authors/${authorId}?${mailto}`);
-      if (!authorRes.ok) throw new Error(`Author request failed with status ${authorRes.status}`);
-      const author = await authorRes.json();
 
       const recentRes = await fetch(`${base}/works?filter=author.id:${authorId}&sort=publication_date:desc&per-page=15&${mailto}`);
       if (!recentRes.ok) throw new Error(`Recent works request failed with status ${recentRes.status}`);
@@ -337,24 +437,53 @@
       if (!topRes.ok) throw new Error(`Top works request failed with status ${topRes.status}`);
       const top = await topRes.json();
 
+      const totals = async () => {
+        let page = 1;
+        let totalCites = 0;
+        let totalPubs = 0;
+        while (true) {
+          const res = await fetch(`${base}/works?filter=author.id:${authorId}&per-page=200&page=${page}&select=id,cited_by_count&${mailto}`);
+          if (!res.ok) break;
+          const data = await res.json();
+          totalPubs = data.meta.count;
+          totalCites += data.results.reduce((s, w) => s + (w.cited_by_count || 0), 0);
+          if (page * data.meta.per_page >= data.meta.count) break;
+          page++;
+        }
+        return { totalPubs, totalCites };
+      };
+      const { totalPubs, totalCites } = await totals();
+
       const mapWork = w => {
-        if (!w.doi && !w.id) return null;
+        const doi = w.doi ? w.doi.replace(/^https?:\/\/doi.org\//i, '') : null;
+        if (!doi && !w.id) return null;
+        let source = w.host_venue?.display_name || w.primary_location?.source?.display_name || '';
+        if ((!source || source === 'Deleted Journal') && /10\.3917\/efrc/i.test(doi || '')) {
+          source = 'EFRC';
+        }
         return {
           title: w.display_name || 'Untitled',
-          link: w.doi ? `https://doi.org/${w.doi}` : w.id,
-          doi: w.doi || null,
+          link: doi ? `https://doi.org/${doi}` : w.id,
+          doi,
           year: w.publication_year || '',
-          citations: w.cited_by_count || 0
+          date: w.publication_date ? new Date(w.publication_date).getTime() : 0,
+          citations: w.cited_by_count || 0,
+          source
         };
       };
 
-      const recentWorks = filterWorks(recent.results.map(mapWork)).slice(0, 5);
-      const recentKeys = new Set(recentWorks.map(w => w.doi || w.link));
-      const topWorks = filterWorks(top.results.map(mapWork).filter(w => !recentKeys.has(w.doi || w.link))).slice(0, 5);
+      const openAlexWorks = [...recent.results.map(mapWork), ...top.results.map(mapWork)];
+      const blogPosts = await loadBlogPosts();
+      const allWorks = dedupeWorks([...openAlexWorks, ...blogPosts]);
+
+      const recentWorks = [...allWorks].sort((a, b) => (b.date || 0) - (a.date || 0)).slice(0, 5);
+      const topWorks = [...allWorks].sort((a, b) => (b.citations || 0) - (a.citations || 0)).slice(0, 5);
+
+      const blogCites = blogPosts.reduce((s, p) => s + (p.citations || 0), 0);
 
       const data = {
-        publications: author.works_count,
-        citations: author.cited_by_count,
+        publications: totalPubs + blogPosts.length,
+        citations: totalCites + blogCites,
         recent: recentWorks,
         top: topWorks,
         updated: Date.now()


### PR DESCRIPTION
## Summary
- Deduplicate works across sources and include source names in the publication list
- Add Carnegie report to curated blog posts and surface website or journal for each entry
- Update footer to credit OpenAlex, Lawfare, CFR, and Carnegie sources

## Testing
- `npm test`
- `node - <<'NODE'
const fs=require('fs');
const posts=JSON.parse(fs.readFileSync('data/blog_posts.json','utf8'));
console.log(posts.map(p=>p.title));
NODE`
- `curl -s "https://api.openalex.org/works?filter=author.id:a5101299489&sort=cited_by_count:desc&per-page=1" | head -c 200`


------
https://chatgpt.com/codex/tasks/task_e_68b76d7df3788321b066689ff5404c53