### PR TITLE
Update robots.txt to remove obsolete cgi-bin rule

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
-Disallow: /cgi-bin
 
 Sitemap: https://apb-ldn.org/sitemap.xml


### PR DESCRIPTION
## Summary
- remove the outdated `/cgi-bin` disallow directive since the site has no CGI directory
- keep the sitemap reference unchanged so crawlers can still discover pages

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c86d1c71548321a04c1dd03bddb7ac