### PR TITLE
Add academic service section

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,17 @@
     </div>
   </section>
 
+  <!-- Academic Service -->
+  <section class="py-12">
+    <div class="max-w-7xl mx-auto px-4">
+      <h2 class="text-3xl font-bold text-center text-indigo-700 mb-8">Academic Service</h2>
+      <ul class="list-disc list-inside space-y-4">
+        <li>Member of the Management Committee of <a href="https://www.cost.eu/actions/CA24154/" target="_blank" rel="noopener noreferrer" class="text-indigo-700 hover:underline">NetSec</a> (Networking European Security Knowledge), a European Cooperation in Science and Technology project.</li>
+        <li>Peer-reviewer for Global Studies Quarterly, the Journal of Cyber Policy, the Journal of International Law and Information Technology, and Defense Studies.</li>
+      </ul>
+    </div>
+  </section>
+
   <!-- Sponsors -->
   <section class="py-12 bg-gray-50">
     <div class="max-w-7xl mx-auto px-4">


### PR DESCRIPTION
## Summary
- insert an Academic Service section between the Publications and Sponsors areas on the home page
- list recent committee membership and peer-review duties using existing list styling
- link the NetSec committee role to the COST project page and remove the date prefix

## Testing
- npx tailwindcss@latest -i src/input.css -o assets/css/tailwind.css --minify *(fails: npm could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68c88af61f1883218a7693efa46cf8e4