### PR TITLE
Add ORCID OAuth callback handler and peer-review feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# APB-LDN.github.io
+
+This repository powers [apb-ldn.org](https://apb-ldn.org/) and now includes lightweight serverless endpoints to keep sensitive
+ORCID credentials on the server while exposing public feeds for the static site.
+
+## Environment configuration
+
+Set the following environment variables in your hosting platform:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `ORCID_CLIENT_ID` | ✅ | Public ORCID application identifier used for both OAuth flows and API calls. |
+| `ORCID_CLIENT_SECRET` | ✅ | Confidential secret used when exchanging tokens; never expose this in the client. |
+| `ORCID_REDIRECT_URI` | ➖ | Optional explicit redirect URI when completing the OAuth code exchange. |
+| `ORCID_PEER_REVIEWS_ORCID` | ✅ | ORCID identifier whose peer-review records should be surfaced on the site. Fallbacks: `ORCID_ID` or `ORCID_PROFILE_ID`. |
+| `ORCID_PEER_REVIEW_SCOPE` | ➖ | Custom scope for peer-review fetches (defaults to `/read-public`). |
+| `ORCID_ALLOWED_ORIGIN` | ➖ | Restrict CORS access to the OAuth callback handler. Defaults to `*`. |
+| `PEER_REVIEWS_ALLOWED_ORIGIN` | ➖ | Restrict CORS access to the peer-review feed handler. Defaults to `*`. |
+
+## Serverless endpoints
+
+The repository exposes two handlers compatible with Node-style serverless platforms (e.g. Vercel, Netlify, Cloudflare Workers
+with Node compatibility):
+
+- `GET/POST /oauth/orcid/callback` exchanges an authorization `code` for tokens via `https://orcid.org/oauth/token`.
+- `GET /api/peer-reviews/latest` requests fresh peer-review data from ORCID using the client credentials flow and returns a
+  normalized JSON payload.
+
+Both handlers live under the `api/` directory and rely on [`undici`](https://github.com/nodejs/undici) for HTTP requests.
+
+## Front-end data flow
+
+- The static fallback list for peer reviews lives in `data/peer-reviews.json` and is merged client-side with the live feed.
+- `assets/js/peer-reviews.js` is loaded on `index.html` and hydrates the Academic Service section by combining the live feed with
+the manual fallback data.
+
+The `<body>` element now exposes the feed and fallback URLs as data attributes so the script can work in different deployment
+contexts without requiring inline secrets.
+
+## Local development
+
+Install dependencies once (only `undici` at the moment):
+
+```bash
+npm install
+```
+
+During development you can invoke either handler locally with Node's built-in HTTP server by wiring the exported function into
+Express, Fastify, or a simple `http.createServer` shim depending on your hosting provider.

--- a/api/oauth/orcid/callback.js
+++ b/api/oauth/orcid/callback.js
@@ -1,0 +1,127 @@
+const { fetch } = require('undici');
+
+const DEFAULT_ALLOWED_ORIGIN = process.env.ORCID_ALLOWED_ORIGIN || '*';
+
+function sendJson(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-store');
+  res.end(JSON.stringify(payload));
+}
+
+function parseQuery(req) {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    return Object.fromEntries(url.searchParams.entries());
+  } catch (error) {
+    return {};
+  }
+}
+
+async function parseBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.from(chunk));
+  }
+  if (!chunks.length) return {};
+  const raw = Buffer.concat(chunks).toString('utf8');
+  const contentType = req.headers['content-type'] || '';
+  try {
+    if (contentType.includes('application/json')) {
+      return JSON.parse(raw);
+    }
+    if (contentType.includes('application/x-www-form-urlencoded')) {
+      return Object.fromEntries(new URLSearchParams(raw));
+    }
+  } catch (error) {
+    return {};
+  }
+  return {};
+}
+
+async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', DEFAULT_ALLOWED_ORIGIN);
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
+  if (!['GET', 'POST'].includes(req.method)) {
+    res.setHeader('Allow', 'GET,POST,OPTIONS');
+    sendJson(res, 405, { error: 'method_not_allowed' });
+    return;
+  }
+
+  const query = parseQuery(req);
+  const body = req.method === 'POST' ? await parseBody(req) : {};
+  const code = query.code || body.code;
+  const redirectUri = body.redirect_uri || query.redirect_uri || process.env.ORCID_REDIRECT_URI;
+  const clientId = process.env.ORCID_CLIENT_ID;
+  const clientSecret = process.env.ORCID_CLIENT_SECRET;
+
+  if (!clientId) {
+    sendJson(res, 500, { error: 'configuration_error', message: 'Missing ORCID_CLIENT_ID environment variable.' });
+    return;
+  }
+
+  if (!clientSecret) {
+    sendJson(res, 500, { error: 'configuration_error', message: 'Missing ORCID_CLIENT_SECRET environment variable.' });
+    return;
+  }
+
+  if (!code) {
+    sendJson(res, 400, { error: 'invalid_request', message: 'Missing OAuth authorization code.' });
+    return;
+  }
+
+  try {
+    const params = new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: 'authorization_code',
+      code
+    });
+
+    if (redirectUri) {
+      params.set('redirect_uri', redirectUri);
+    }
+
+    const tokenResponse = await fetch('https://orcid.org/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'application/json'
+      },
+      body: params.toString()
+    });
+
+    const payload = await tokenResponse.json();
+
+    if (!tokenResponse.ok) {
+      sendJson(res, tokenResponse.status, {
+        error: 'token_exchange_failed',
+        message: payload.error_description || 'ORCID token exchange failed.',
+        details: payload
+      });
+      return;
+    }
+
+    sendJson(res, 200, {
+      ...payload,
+      receivedAt: new Date().toISOString()
+    });
+  } catch (error) {
+    sendJson(res, 502, {
+      error: 'token_exchange_error',
+      message: 'Unable to complete the ORCID token exchange.',
+      details: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+}
+
+module.exports = handler;
+module.exports.default = handler;

--- a/api/peer-reviews/latest.js
+++ b/api/peer-reviews/latest.js
@@ -1,0 +1,254 @@
+const { fetch } = require('undici');
+
+const HTTP_OK = 200;
+const DEFAULT_SCOPE = process.env.ORCID_PEER_REVIEW_SCOPE || '/read-public';
+const ORCID_BASE_URL = process.env.ORCID_BASE_URL || 'https://api.orcid.org/v3.0';
+const DEFAULT_ALLOWED_ORIGIN = process.env.PEER_REVIEWS_ALLOWED_ORIGIN || '*';
+
+function sendJson(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-store');
+  res.end(JSON.stringify(payload));
+}
+
+function normaliseYear(value) {
+  if (!value) return null;
+  const str = String(value).trim();
+  if (!/^\d{4}$/.test(str)) return null;
+  const int = Number(str);
+  return Number.isFinite(int) ? int : null;
+}
+
+function slugify(input) {
+  return (input || '')
+    .toString()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120);
+}
+
+function ensureArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === undefined || value === null) return [];
+  return [value];
+}
+
+function collectSummaries(payload) {
+  const groups = ensureArray(payload?.['peer-review-group']);
+  const summaries = [];
+  for (const group of groups) {
+    const groupSummaries = ensureArray(group?.['peer-review-summary']);
+    for (const summary of groupSummaries) {
+      summaries.push({
+        summary,
+        group
+      });
+    }
+  }
+  return summaries;
+}
+
+function extractValue(candidate, fallback) {
+  if (!candidate) return fallback;
+  if (typeof candidate === 'string') return candidate || fallback;
+  if (typeof candidate === 'object') {
+    if ('value' in candidate && candidate.value) return candidate.value;
+  }
+  return fallback;
+}
+
+function normaliseSummary(record) {
+  const summary = record.summary || {};
+  const group = record.group || {};
+  const completionYear = normaliseYear(summary?.['completion-date']?.year?.value || summary?.['completion-date']?.value);
+  const containerName = extractValue(summary?.['subject-container-name'], null);
+  const subjectName = extractValue(summary?.['subject-name'], null);
+  const reviewGroupType = extractValue(summary?.['review-group-type'], null);
+  const name = containerName || subjectName || reviewGroupType || 'Peer review';
+  const id = slugify(name) || (summary?.['put-code'] ? `put-${summary['put-code']}` : undefined) || slugify(reviewGroupType) || slugify(subjectName) || slugify(containerName) || 'peer-review';
+  const reviewerOrg = extractValue(summary?.['reviewer-org']?.name, extractValue(group?.['reviewer-org']?.name, null));
+  const organization = reviewerOrg || extractValue(group?.['organization']?.name, null) || extractValue(summary?.['organization']?.name, null);
+  const role = extractValue(summary?.['reviewer-role']?.value, extractValue(summary?.['review-type']?.value, null));
+  const url = extractValue(summary?.url?.value, extractValue(summary?.['subject-url']?.value, null));
+  const groupId = extractValue(group?.['group-id'], extractValue(summary?.['group-id'], null));
+  const identifiers = ensureArray(summary?.['external-identifiers']?.['external-identifier']);
+  const aliasValues = identifiers
+    .map(identifier => extractValue(identifier?.['external-identifier-value'], null))
+    .filter(Boolean);
+  const putCode = summary?.['put-code'] ? String(summary['put-code']) : null;
+
+  return {
+    id,
+    name,
+    organization: organization || '',
+    role: role || '',
+    years: completionYear ? [completionYear] : [],
+    lastReviewed: completionYear || null,
+    url: url || null,
+    source: 'orcid',
+    groupIds: groupId ? [groupId] : [],
+    aliases: aliasValues,
+    putCodes: putCode ? [putCode] : []
+  };
+}
+
+function aggregatePeerReviews(payload) {
+  const aggregated = new Map();
+  for (const record of collectSummaries(payload)) {
+    const entry = normaliseSummary(record);
+    const key = entry.groupIds[0] || entry.id;
+    const existing = aggregated.get(key);
+    if (!existing) {
+      aggregated.set(key, entry);
+      continue;
+    }
+
+    const yearSet = new Set([...(existing.years || []), ...(entry.years || [])].filter(Number.isFinite));
+    const combinedYears = Array.from(yearSet).sort((a, b) => b - a);
+    existing.years = combinedYears;
+    existing.lastReviewed = combinedYears[0] || existing.lastReviewed || entry.lastReviewed || null;
+
+    if (!existing.name && entry.name) existing.name = entry.name;
+    if (entry.name && entry.name.length > (existing.name || '').length) existing.name = entry.name;
+
+    if (entry.organization && (!existing.organization || entry.organization.length > existing.organization.length)) {
+      existing.organization = entry.organization;
+    }
+
+    if (entry.role && !existing.role) {
+      existing.role = entry.role;
+    }
+
+    if (entry.url && !existing.url) {
+      existing.url = entry.url;
+    }
+
+    existing.aliases = Array.from(new Set([...(existing.aliases || []), ...(entry.aliases || [])]));
+    existing.groupIds = Array.from(new Set([...(existing.groupIds || []), ...(entry.groupIds || [])].filter(Boolean)));
+    existing.putCodes = Array.from(new Set([...(existing.putCodes || []), ...(entry.putCodes || [])].filter(Boolean)));
+  }
+
+  const entries = Array.from(aggregated.values()).map(item => {
+    const years = Array.isArray(item.years) ? item.years.filter(Number.isFinite).sort((a, b) => b - a) : [];
+    return {
+      ...item,
+      years,
+      lastReviewed: years[0] || item.lastReviewed || null
+    };
+  });
+
+  entries.sort((a, b) => {
+    const aYear = a.lastReviewed || 0;
+    const bYear = b.lastReviewed || 0;
+    if (aYear !== bYear) return bYear - aYear;
+    return a.name.localeCompare(b.name);
+  });
+
+  return entries;
+}
+
+async function fetchPeerReviews() {
+  const clientId = process.env.ORCID_CLIENT_ID;
+  const clientSecret = process.env.ORCID_CLIENT_SECRET;
+  const orcidId = process.env.ORCID_PEER_REVIEWS_ORCID || process.env.ORCID_ID || process.env.ORCID_PROFILE_ID;
+
+  if (!clientId || !clientSecret || !orcidId) {
+    throw new Error('Missing ORCID configuration. Ensure ORCID_CLIENT_ID, ORCID_CLIENT_SECRET and ORCID_PEER_REVIEWS_ORCID are set.');
+  }
+
+  const tokenParams = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'client_credentials',
+    scope: DEFAULT_SCOPE
+  });
+
+  const tokenResponse = await fetch('https://orcid.org/oauth/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'application/json'
+    },
+    body: tokenParams.toString()
+  });
+
+  const tokenPayload = await tokenResponse.json();
+  if (!tokenResponse.ok) {
+    const error = tokenPayload?.error_description || tokenPayload?.error || 'ORCID token request failed.';
+    throw new Error(error);
+  }
+
+  if (!tokenPayload?.access_token) {
+    throw new Error('ORCID token response did not include an access token.');
+  }
+
+  const peerReviewUrl = `${ORCID_BASE_URL.replace(/\/$/, '')}/${encodeURIComponent(orcidId)}/peer-reviews`;
+
+  const peerResponse = await fetch(peerReviewUrl, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${tokenPayload.access_token}`,
+      Accept: 'application/json'
+    }
+  });
+
+  const payload = await peerResponse.json();
+  if (!peerResponse.ok) {
+    const error = payload?.userMessage || payload?.developerMessage || 'ORCID peer review fetch failed.';
+    throw new Error(error);
+  }
+
+  return {
+    meta: {
+      fetchedAt: new Date().toISOString(),
+      orcidId,
+      totalGroups: Array.isArray(payload?.['peer-review-group']) ? payload['peer-review-group'].length : 0
+    },
+    entries: aggregatePeerReviews(payload)
+  };
+}
+
+async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', DEFAULT_ALLOWED_ORIGIN);
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET,OPTIONS');
+    sendJson(res, 405, { error: 'method_not_allowed' });
+    return;
+  }
+
+  try {
+    const result = await fetchPeerReviews();
+    sendJson(res, HTTP_OK, {
+      meta: {
+        ...result.meta,
+        source: 'orcid'
+      },
+      entries: result.entries
+    });
+  } catch (error) {
+    sendJson(res, HTTP_OK, {
+      meta: {
+        fetchedAt: new Date().toISOString(),
+        source: 'fallback',
+        error: error instanceof Error ? error.message : 'Unknown error'
+      },
+      entries: []
+    });
+  }
+}
+
+module.exports = handler;
+module.exports.default = handler;

--- a/assets/js/peer-reviews.js
+++ b/assets/js/peer-reviews.js
@@ -1,0 +1,257 @@
+const bodyDataset = document.body?.dataset || {};
+const listSelector = '[data-peer-reviews-list]';
+
+const classes = {
+  listItem:
+    'flex items-start gap-3 rounded-lg border border-indigo-100 bg-white/80 p-4 shadow-sm transition-shadow hover:shadow-md',
+  iconWrapper: 'mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-white',
+  title: 'text-base font-semibold text-gray-900',
+  meta: 'mt-1 text-sm text-gray-600',
+  metaLabel: 'font-medium text-gray-700'
+};
+
+const fallbackUrl = bodyDataset.peerReviewsFallback || '/data/peer-reviews.json';
+const feedUrl = bodyDataset.peerReviewsFeed || '/api/peer-reviews/latest';
+const updatedTargetId = bodyDataset.peerReviewsUpdatedTarget || null;
+
+const isIsoDate = value => typeof value === 'string' && !Number.isNaN(Date.parse(value));
+
+function slugify(text) {
+  return (text || '')
+    .toString()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120);
+}
+
+function uniqueSortedYears(years) {
+  return Array.from(
+    new Set((Array.isArray(years) ? years : []).map(value => {
+      const n = Number(value);
+      return Number.isFinite(n) ? n : null;
+    }).filter(value => value !== null))
+  ).sort((a, b) => b - a);
+}
+
+function parseEntry(entry, defaultSource = 'manual') {
+  if (!entry || typeof entry !== 'object') return null;
+  const years = uniqueSortedYears(entry.years);
+  const normalized = {
+    id: entry.id || slugify(entry.name || entry.organization || entry.groupIds?.[0] || ''),
+    name: entry.name || '',
+    organization: entry.organization || '',
+    role: entry.role || entry.reviewRole || '',
+    years,
+    lastReviewed: entry.lastReviewed || (years[0] || null),
+    url: entry.url || null,
+    source: entry.source || defaultSource,
+    groupIds: Array.isArray(entry.groupIds) ? Array.from(new Set(entry.groupIds.filter(Boolean))) : [],
+    aliases: Array.isArray(entry.aliases) ? Array.from(new Set(entry.aliases.filter(Boolean))) : [],
+    putCodes: Array.isArray(entry.putCodes) ? Array.from(new Set(entry.putCodes.filter(Boolean))) : []
+  };
+
+  if (!normalized.id) {
+    normalized.id = slugify(`${normalized.name}-${normalized.organization}`);
+  }
+
+  return normalized;
+}
+
+function findMatchingManual(remoteEntry, manualIndex) {
+  if (!remoteEntry) return null;
+  if (manualIndex.has(remoteEntry.id)) return manualIndex.get(remoteEntry.id);
+
+  const candidates = Array.from(manualIndex.values());
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (remoteEntry.name && candidate.name && remoteEntry.name.toLowerCase() === candidate.name.toLowerCase()) {
+      return candidate;
+    }
+    const sharedGroupId = remoteEntry.groupIds?.some(id => candidate.groupIds?.includes(id));
+    if (sharedGroupId) return candidate;
+    const sharedAlias = remoteEntry.aliases?.some(alias => candidate.aliases?.includes(alias));
+    if (sharedAlias) return candidate;
+  }
+
+  return null;
+}
+
+function mergeEntries(manualEntries, remoteEntries) {
+  const manualIndex = new Map();
+  for (const manual of manualEntries) {
+    const parsed = parseEntry(manual, 'manual');
+    if (parsed) {
+      manualIndex.set(parsed.id, parsed);
+    }
+  }
+
+  const merged = [];
+  const consumedManual = new Set();
+
+  for (const remote of remoteEntries) {
+    const parsedRemote = parseEntry(remote, 'remote');
+    if (!parsedRemote) continue;
+    const manualMatch = findMatchingManual(parsedRemote, manualIndex);
+
+    if (manualMatch) {
+      consumedManual.add(manualMatch.id);
+      const years = uniqueSortedYears([...manualMatch.years, ...parsedRemote.years]);
+      const mergedEntry = {
+        id: parsedRemote.id || manualMatch.id,
+        name: parsedRemote.name || manualMatch.name,
+        organization: parsedRemote.organization || manualMatch.organization,
+        role: parsedRemote.role || manualMatch.role,
+        years,
+        lastReviewed: parsedRemote.lastReviewed || manualMatch.lastReviewed || (years[0] || null),
+        url: parsedRemote.url || manualMatch.url || null,
+        source: parsedRemote.source === 'remote' && manualMatch.source === 'manual' ? 'merged' : parsedRemote.source,
+        groupIds: Array.from(new Set([...(manualMatch.groupIds || []), ...(parsedRemote.groupIds || [])])),
+        aliases: Array.from(new Set([...(manualMatch.aliases || []), ...(parsedRemote.aliases || [])])),
+        putCodes: Array.from(new Set([...(manualMatch.putCodes || []), ...(parsedRemote.putCodes || [])]))
+      };
+      merged.push(mergedEntry);
+      continue;
+    }
+
+    merged.push(parsedRemote);
+  }
+
+  for (const [manualId, manualEntry] of manualIndex.entries()) {
+    if (!consumedManual.has(manualId)) {
+      merged.push(manualEntry);
+    }
+  }
+
+  return merged
+    .map(entry => ({
+      ...entry,
+      years: uniqueSortedYears(entry.years),
+      lastReviewed: entry.lastReviewed || (entry.years[0] || null)
+    }))
+    .sort((a, b) => {
+      const aYear = a.lastReviewed || 0;
+      const bYear = b.lastReviewed || 0;
+      if (aYear !== bYear) return bYear - aYear;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+async function fetchJson(url) {
+  if (!url) return null;
+  try {
+    const response = await fetch(url, {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' }
+    });
+    if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
+    return await response.json();
+  } catch (error) {
+    console.error('Failed to fetch JSON', url, error);
+    return null;
+  }
+}
+
+async function loadPeerReviews() {
+  const [manualPayload, remotePayload] = await Promise.all([
+    fetchJson(fallbackUrl),
+    feedUrl ? fetchJson(feedUrl) : Promise.resolve(null)
+  ]);
+
+  const manualEntries = Array.isArray(manualPayload?.entries) ? manualPayload.entries : [];
+  const remoteEntries = Array.isArray(remotePayload?.entries) ? remotePayload.entries : [];
+
+  const merged = mergeEntries(manualEntries, remoteEntries);
+
+  return {
+    entries: merged,
+    manualMeta: manualPayload?.meta || null,
+    remoteMeta: remotePayload?.meta || null
+  };
+}
+
+function createIcon() {
+  return `
+    <span class="${classes.iconWrapper}">
+      <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-7.5 9.5a.75.75 0 0 1-1.127.075l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.887 2.886 6.977-8.844a.75.75 0 0 1 1.06-.109z" clip-rule="evenodd"></path>
+      </svg>
+    </span>
+  `;
+}
+
+function renderEntries(target, entries) {
+  target.innerHTML = '';
+  if (!entries.length) {
+    const li = document.createElement('li');
+    li.className = classes.listItem;
+    li.innerHTML = `${createIcon()}<div><p class="${classes.title}">Peer review activity</p><p class="${classes.meta}">No peer review data is available at this time.</p></div>`;
+    target.appendChild(li);
+    return;
+  }
+
+  for (const entry of entries) {
+    const li = document.createElement('li');
+    li.className = classes.listItem;
+    const journal = entry.name || 'Peer review';
+    const org = entry.organization || '';
+    const yearsText = entry.years.length ? entry.years.join(', ') : (entry.lastReviewed || '');
+    const metaParts = [org ? `<span class="${classes.metaLabel}">${org}</span>` : null, yearsText || null].filter(Boolean);
+    const anchorStart = entry.url ? `<a href="${entry.url}" class="text-indigo-700 hover:underline" target="_blank" rel="noopener noreferrer">` : '';
+    const anchorEnd = entry.url ? '</a>' : '';
+
+    li.innerHTML = `
+      ${createIcon()}
+      <div>
+        <p class="${classes.title}">${anchorStart}${journal}${anchorEnd}</p>
+        <p class="${classes.meta}">${metaParts.join(' · ')}</p>
+      </div>
+    `;
+
+    target.appendChild(li);
+  }
+}
+
+function updateMeta(remoteMeta, manualMeta) {
+  if (!updatedTargetId) return;
+  const target = document.getElementById(updatedTargetId);
+  if (!target) return;
+
+  const remoteDate = remoteMeta?.fetchedAt && isIsoDate(remoteMeta.fetchedAt)
+    ? new Date(remoteMeta.fetchedAt)
+    : null;
+  const manualDate = manualMeta?.manualUpdatedAt && isIsoDate(manualMeta.manualUpdatedAt)
+    ? new Date(manualMeta.manualUpdatedAt)
+    : null;
+
+  if (remoteDate) {
+    target.textContent = `Last updated ${remoteDate.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}`;
+    return;
+  }
+
+  if (manualDate) {
+    target.textContent = `Last updated ${manualDate.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}`;
+  }
+}
+
+async function initialisePeerReviews() {
+  const list = document.querySelector(listSelector);
+  if (!list) return;
+
+  const placeholder = list.querySelector('[data-peer-reviews-placeholder]');
+  if (placeholder) {
+    placeholder.remove();
+  }
+
+  const { entries, manualMeta, remoteMeta } = await loadPeerReviews();
+  renderEntries(list, entries);
+  updateMeta(remoteMeta, manualMeta);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initialisePeerReviews, { once: true });
+} else {
+  initialisePeerReviews();
+}

--- a/data/peer-reviews.json
+++ b/data/peer-reviews.json
@@ -1,0 +1,49 @@
+{
+  "meta": {
+    "manualUpdatedAt": "2025-06-17T00:00:00.000Z",
+    "note": "Fallback list maintained manually to ensure peer-review activity is always displayed even when live feeds are unavailable."
+  },
+  "entries": [
+    {
+      "id": "journal-of-international-law-and-information-technology",
+      "name": "Journal of International Law and Information Technology",
+      "organization": "Oxford University Press",
+      "role": "Peer Reviewer",
+      "years": [2020, 2024],
+      "lastReviewed": 2024,
+      "url": "https://academic.oup.com/jilit",
+      "groupIds": ["journal-of-international-law-and-information-technology"],
+      "aliases": ["JILIT"]
+    },
+    {
+      "id": "journal-of-cyber-policy",
+      "name": "Journal of Cyber Policy",
+      "organization": "Routledge",
+      "role": "Peer Reviewer",
+      "years": [2022],
+      "lastReviewed": 2022,
+      "url": "https://www.tandfonline.com/journals/rcyb20",
+      "groupIds": ["journal-of-cyber-policy"]
+    },
+    {
+      "id": "global-studies-quarterly",
+      "name": "Global Studies Quarterly",
+      "organization": "Oxford University Press",
+      "role": "Peer Reviewer",
+      "years": [2022, 2023],
+      "lastReviewed": 2023,
+      "url": "https://academic.oup.com/isagsq",
+      "groupIds": ["global-studies-quarterly"]
+    },
+    {
+      "id": "defence-studies",
+      "name": "Defence Studies",
+      "organization": "Routledge",
+      "role": "Peer Reviewer",
+      "years": [2025],
+      "lastReviewed": 2025,
+      "url": "https://www.tandfonline.com/journals/fdst20",
+      "groupIds": ["defence-studies"]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,12 @@
   <link rel="stylesheet" href="assets/css/tailwind.css">
   <style>body{font-family:'Inter',sans-serif}</style>
 </head>
-<body class="text-gray-800">
+<body
+  class="text-gray-800"
+  data-peer-reviews-feed="/api/peer-reviews/latest"
+  data-peer-reviews-fallback="/data/peer-reviews.json"
+  data-peer-reviews-updated-target="peer-reviews-last-updated"
+>
 
 <header class="bg-indigo-600 text-white">
   <div class="max-w-7xl mx-auto px-4 py-12 flex flex-col md:flex-row items-center">
@@ -201,52 +206,15 @@
         <p>Member of the Management Committee of <a href="https://www.cost.eu/actions/CA24154/" target="_blank" rel="noopener noreferrer" class="text-indigo-700 hover:underline">NetSec</a> (Networking European Security Knowledge), a European Cooperation in Science and Technology project.</p>
         <div>
           <p>Peer reviewer for the following journals:</p>
-          <ul class="grid gap-4 sm:grid-cols-2">
-            <li class="flex items-start gap-3 rounded-lg border border-indigo-100 bg-white/80 p-4 shadow-sm transition-shadow hover:shadow-md">
-              <span class="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-white">
-                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-7.5 9.5a.75.75 0 0 1-1.127.075l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.887 2.886 6.977-8.844a.75.75 0 0 1 1.06-.109z" clip-rule="evenodd" />
-                </svg>
-              </span>
-              <div>
-                <p class="text-base font-semibold text-gray-900"><em>Journal of International Law and Information Technology</em></p>
-                <p class="mt-1 text-sm text-gray-600"><span class="font-medium text-gray-700">Oxford University Press</span> · 2020, 2024</p>
-              </div>
-            </li>
-            <li class="flex items-start gap-3 rounded-lg border border-indigo-100 bg-white/80 p-4 shadow-sm transition-shadow hover:shadow-md">
-              <span class="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-white">
-                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-7.5 9.5a.75.75 0 0 1-1.127.075l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.887 2.886 6.977-8.844a.75.75 0 0 1 1.06-.109z" clip-rule="evenodd" />
-                </svg>
-              </span>
-              <div>
-                <p class="text-base font-semibold text-gray-900"><em>Journal of Cyber Policy</em></p>
-                <p class="mt-1 text-sm text-gray-600"><span class="font-medium text-gray-700">Routledge</span> · 2022</p>
-              </div>
-            </li>
-            <li class="flex items-start gap-3 rounded-lg border border-indigo-100 bg-white/80 p-4 shadow-sm transition-shadow hover:shadow-md">
-              <span class="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-white">
-                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-7.5 9.5a.75.75 0 0 1-1.127.075l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.887 2.886 6.977-8.844a.75.75 0 0 1 1.06-.109z" clip-rule="evenodd" />
-                </svg>
-              </span>
-              <div>
-                <p class="text-base font-semibold text-gray-900"><em>Global Studies Quarterly</em></p>
-                <p class="mt-1 text-sm text-gray-600"><span class="font-medium text-gray-700">Oxford University Press</span> · 2022, 2023</p>
-              </div>
-            </li>
-            <li class="flex items-start gap-3 rounded-lg border border-indigo-100 bg-white/80 p-4 shadow-sm transition-shadow hover:shadow-md">
-              <span class="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-white">
-                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-7.5 9.5a.75.75 0 0 1-1.127.075l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.887 2.886 6.977-8.844a.75.75 0 0 1 1.06-.109z" clip-rule="evenodd" />
-                </svg>
-              </span>
-              <div>
-                <p class="text-base font-semibold text-gray-900"><em>Defence Studies</em></p>
-                <p class="mt-1 text-sm text-gray-600"><span class="font-medium text-gray-700">Routledge</span> · 2025</p>
-              </div>
+          <ul class="grid gap-4 sm:grid-cols-2" data-peer-reviews-list>
+            <li
+              class="flex items-start gap-3 rounded-lg border border-dashed border-indigo-100 bg-white/50 p-4 text-sm text-gray-500"
+              data-peer-reviews-placeholder
+            >
+              Loading peer review activity…
             </li>
           </ul>
+          <p id="peer-reviews-last-updated" class="mt-3 text-sm text-gray-500"></p>
         </div>
       </div>
     </div>
@@ -319,6 +287,7 @@
     </div>
    </footer>
 
+<script type="module" src="assets/js/peer-reviews.js"></script>
 <script>
   async function loadBlogPosts() {
     const CACHE_KEY = 'blogPosts';


### PR DESCRIPTION
## Summary
- add a serverless callback at `/oauth/orcid/callback` to exchange ORCID authorization codes using credentials stored in the environment
- expose `/api/peer-reviews/latest` for server-side aggregation of peer-review data and document the required environment variables
- hydrate the Academic Service section from the protected feed with a resilient client script backed by a manual JSON fallback

## Testing
- node -e "require('./api/oauth/orcid/callback.js')"
- node -e "require('./api/peer-reviews/latest.js')"


------
https://chatgpt.com/codex/tasks/task_e_68cb48ae92d88321b80e565092089561